### PR TITLE
Allow setting custom class names

### DIFF
--- a/src/typeahead-standalone.ts
+++ b/src/typeahead-standalone.ts
@@ -91,7 +91,7 @@ export default function typeahead<T extends Dictionary>(config: typeaheadConfig<
   }
 
   const input: HTMLInputElement = config.input;
-  input.classList.add('tt-input');
+  input.classList.add(config.classNames?.input ?? 'tt-input');
 
   // Wrapper element
   const wrapper: HTMLSpanElement = doc.createElement('span');
@@ -111,7 +111,7 @@ export default function typeahead<T extends Dictionary>(config: typeaheadConfig<
   const inputHint: HTMLInputElement = input.cloneNode() as HTMLInputElement;
   hint && injectHintEl(inputHint);
 
-  listContainer.classList.add('tt-list', 'tt-hide');
+  listContainer.classList.add(config.classNames?.list ?? 'tt-list', config.classNames?.hide ?? 'tt-hide');
   listContainer.tabIndex = 0;
   listContainer.setAttribute('aria-label', 'menu-options');
   listContainer.setAttribute('role', 'listbox');
@@ -158,21 +158,21 @@ export default function typeahead<T extends Dictionary>(config: typeaheadConfig<
    * Display/show the listContainer
    */
   const show = (): void => {
-    listContainer.classList.remove('tt-hide');
+    listContainer.classList.remove(config.classNames?.hide ?? 'tt-hide');
   };
 
   /**
    * Hides the listContainer from DOM
    */
   const hide = (): void => {
-    listContainer.classList.add('tt-hide');
+    listContainer.classList.add(config.classNames?.hide ?? 'tt-hide');
   };
 
   /**
    * Flag to indicate if the list of suggestions is open or not
    * @returns Boolean
    */
-  const isListOpen = (): boolean => !listContainer.classList.contains('tt-hide');
+  const isListOpen = (): boolean => !listContainer.classList.contains(config.classNames?.hide ?? 'tt-hide');
 
   /**
    * Clear remote debounce timer if assigned
@@ -209,7 +209,7 @@ export default function typeahead<T extends Dictionary>(config: typeaheadConfig<
 
       const renderNotFoundTemplate = (html: string) => {
         const notFoundEl = doc.createElement('div');
-        notFoundEl.classList.add('tt-notFound');
+        notFoundEl.classList.add(config.classNames?.notFound ?? 'tt-notFound');
         templatify(notFoundEl, html);
         listContainer.appendChild(notFoundEl);
       };
@@ -241,17 +241,20 @@ export default function typeahead<T extends Dictionary>(config: typeaheadConfig<
     }
 
     if (!fetchInProgress) {
-      const loaderEl = listContainer.querySelector('.tt-loader');
+      const loaderEl = listContainer.querySelector(`.${config.classNames?.loader ?? 'tt-loader'}`);
       loaderEl && listContainer.removeChild(loaderEl);
       return;
     }
 
     // display spinner/loader
     const loaderDiv = doc.createElement('div');
-    loaderDiv.classList.add('tt-loader');
+    loaderDiv.classList.add(config.classNames?.loader ?? 'tt-loader');
     templatify(loaderDiv, templates.loader());
     if (templates?.footer) {
-      listContainer.insertBefore(loaderDiv, listContainer.querySelector('.tt-footer'));
+      listContainer.insertBefore(
+        loaderDiv,
+        listContainer.querySelector(`.${config.classNames?.footer ?? 'tt-footer'}`)
+      );
     } else {
       listContainer.appendChild(loaderDiv);
     }
@@ -269,7 +272,7 @@ export default function typeahead<T extends Dictionary>(config: typeaheadConfig<
     // function for rendering typeahead suggestions
     const render = (item: T): HTMLDivElement => {
       const itemElement = doc.createElement('div');
-      itemElement.classList.add('tt-suggestion');
+      itemElement.classList.add(config.classNames?.suggestion ?? 'tt-suggestion');
       itemElement.setAttribute('role', 'option');
       itemElement.setAttribute('aria-selected', 'false');
       itemElement.setAttribute('aria-label', display(item));
@@ -284,7 +287,7 @@ export default function typeahead<T extends Dictionary>(config: typeaheadConfig<
     // function to render typeahead groups
     const renderGroup = (groupName: string): HTMLDivElement => {
       const groupDiv = doc.createElement('div');
-      groupDiv.classList.add('tt-group');
+      groupDiv.classList.add(config.classNames?.group ?? 'tt-group');
       groupDiv.setAttribute('role', 'group');
       groupDiv.setAttribute('aria-label', groupName);
       if (templates?.group) {
@@ -301,7 +304,7 @@ export default function typeahead<T extends Dictionary>(config: typeaheadConfig<
     // Add header template
     if (templates?.header) {
       const headerDiv = doc.createElement('div');
-      headerDiv.classList.add('tt-header');
+      headerDiv.classList.add(config.classNames?.header ?? 'tt-header');
       headerDiv.setAttribute('role', 'heading');
       headerDiv.setAttribute('aria-level', '1');
       const templateHtml = templatify(headerDiv, templates.header(resultSet));
@@ -328,7 +331,7 @@ export default function typeahead<T extends Dictionary>(config: typeaheadConfig<
         ev.preventDefault();
       });
       if (item === selected) {
-        div.classList.add('tt-selected');
+        div.classList.add(config.classNames?.selected ?? 'tt-selected');
         div.setAttribute('aria-selected', 'true');
       }
       fragment.appendChild(div);
@@ -340,7 +343,7 @@ export default function typeahead<T extends Dictionary>(config: typeaheadConfig<
     // Add footer template
     if (templates?.footer) {
       const footerDiv = doc.createElement('div');
-      footerDiv.classList.add('tt-footer');
+      footerDiv.classList.add(config.classNames?.footer ?? 'tt-footer');
       footerDiv.setAttribute('role', 'heading');
       footerDiv.setAttribute('aria-level', '2');
       const templateHtml = templatify(footerDiv, templates.footer(resultSet));
@@ -353,7 +356,7 @@ export default function typeahead<T extends Dictionary>(config: typeaheadConfig<
     hint && updateHint(selected || resultSet.items[0]);
 
     // scroll when not in view
-    listContainer.querySelector('.tt-selected')?.scrollIntoView({ block: 'nearest' });
+    listContainer.querySelector(`.${config.classNames?.loader ?? 'tt-selected'}`)?.scrollIntoView({ block: 'nearest' });
 
     show();
   };
@@ -495,7 +498,7 @@ export default function typeahead<T extends Dictionary>(config: typeaheadConfig<
       clear();
       clearListDOM();
       const emptyEl = doc.createElement('div');
-      emptyEl.classList.add('tt-empty');
+      emptyEl.classList.add(config.classNames?.empty ?? 'tt-empty');
       templatify(emptyEl, emptyHtml);
       emptyHtml && listContainer.appendChild(emptyEl);
       return show();
@@ -687,7 +690,7 @@ export default function typeahead<T extends Dictionary>(config: typeaheadConfig<
       }
 
       const wrapperNode = doc.createElement('span');
-      wrapperNode.className = 'tt-highlight';
+      wrapperNode.className = config.classNames?.highlight ?? 'tt-highlight';
 
       if (match) {
         const patternNode = textNode.splitText(match.index);
@@ -728,7 +731,7 @@ export default function typeahead<T extends Dictionary>(config: typeaheadConfig<
     inputHint.setAttribute('readonly', 'true');
     inputHint.setAttribute('aria-hidden', 'true');
     inputHint.tabIndex = -1;
-    inputHint.className = 'tt-hint';
+    inputHint.className = config.classNames?.hint ?? 'tt-hint';
 
     input.after(inputHint);
   }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -45,6 +45,7 @@ export interface typeaheadHtmlTemplates<T extends Dictionary> {
 export interface typeaheadConfig<T extends Dictionary> {
   input: HTMLInputElement;
   className?: string;
+  classNames?: Record<string, string>;
   minLength?: number;
   limit?: number;
   hint?: boolean;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: [#xxx]`, where "xxx" is the issue number)
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/digitalfortress-tech/localstorage-slim#readme) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.


**Other information:**
Created a discussion here https://github.com/digitalfortress-tech/typeahead-standalone/discussions/50

Not sure if this is how you would want it implemented _(if at all)_, so figured I would open a PR first and go from there.

This PR allows users to set a custom class name for specific elements instead of the default class names.

Use case being when using multiple themes instead of having to add a bunch more custom css specifically for typeahead-standalone, you can just set your existing custom classes.