### PR TITLE
fix: only scroll window if selected suggestion is out of view

### DIFF
--- a/src/typeahead-standalone.ts
+++ b/src/typeahead-standalone.ts
@@ -374,6 +374,7 @@ const typeahead = <T extends Dictionary>(config: typeaheadConfig<T>): typeaheadR
 
     listContainer.appendChild(fragment);
 
+    // update hint if its enabled
     hint && updateHint(selected || resultSet.hits[0]);
 
     // scroll when not in view

--- a/src/typeahead-standalone.ts
+++ b/src/typeahead-standalone.ts
@@ -634,7 +634,6 @@ const typeahead = <T extends Dictionary>(config: typeaheadConfig<T>): typeaheadR
 
     let transformed: T[] = [];
 
-
     fetchWrapper
       .get(
         typeof remote.url === 'function'

--- a/src/typeahead-standalone.ts
+++ b/src/typeahead-standalone.ts
@@ -374,35 +374,8 @@ const typeahead = <T extends Dictionary>(config: typeaheadConfig<T>): typeaheadR
 
     listContainer.appendChild(fragment);
 
-    // update hint if its enabled
-    hint && updateHint(selected || resultSet.hits[0]);
-
-    const scrollIntoViewIfNeeded = (container: HTMLDivElement, element: HTMLDivElement) => {
-      if (container === null || element === null) return;
-
-      const containerRect = container.getBoundingClientRect();
-      const elementRect = element.getBoundingClientRect();
-
-      const isAbove = elementRect.top < containerRect.top;
-      const isBelow = elementRect.bottom > containerRect.bottom;
-      const isLeft = elementRect.left < containerRect.left;
-      const isRight = elementRect.right > containerRect.right;
-
-      if (isAbove) {
-        container.scrollBy({ top: elementRect.top - containerRect.top - 10, behavior: 'smooth' });
-      } else if (isBelow) {
-        container.scrollBy({ top: elementRect.bottom - containerRect.bottom + 10, behavior: 'smooth' });
-      }
-
-      if (isLeft) {
-        container.scrollBy({ left: elementRect.left - containerRect.left - 10, behavior: 'smooth' });
-      } else if (isRight) {
-        container.scrollBy({ left: elementRect.right - containerRect.right + 10, behavior: 'smooth' });
-      }
-    };
     // scroll when not in view
-    scrollIntoViewIfNeeded(listContainer, listContainer.querySelector(`.${classNames.selected}`) as HTMLDivElement);
-
+    listContainer.querySelector(`.${classNames.selected}`)?.scrollIntoView({ block: 'nearest', behavior: 'smooth'});
     show();
   };
 

--- a/src/typeahead-standalone.ts
+++ b/src/typeahead-standalone.ts
@@ -634,9 +634,12 @@ const typeahead = <T extends Dictionary>(config: typeaheadConfig<T>): typeaheadR
 
     let transformed: T[] = [];
 
+
     fetchWrapper
       .get(
-        typeof remote.url === 'function' ? remote.url(frozenInput) : remote.url.replace(remote.wildcard!, frozenInput),
+        typeof remote.url === 'function'
+          ? remote.url(frozenInput)
+          : remote.url.replace(remote.wildcard!, frozenInput),
         remote.requestOptions
       )
       .then(

--- a/src/typeahead-standalone.ts
+++ b/src/typeahead-standalone.ts
@@ -377,8 +377,35 @@ const typeahead = <T extends Dictionary>(config: typeaheadConfig<T>): typeaheadR
     // update hint if its enabled
     hint && updateHint(selected || resultSet.hits[0]);
 
+    const scrollIntoViewIfNeeded = (element: HTMLDivElement) => {
+      if (element === null) return;
+      const rect = element.getBoundingClientRect();
+
+      const isAbove = rect.top < 0;
+      const isBelow = rect.bottom > (window.innerHeight || document.documentElement.clientHeight);
+      const isLeft = rect.left < 0;
+      const isRight = rect.right > (window.innerWidth || document.documentElement.clientWidth);
+
+      if (isAbove) {
+        window.scrollBy({ top: rect.top - 10, behavior: 'smooth' });
+      } else if (isBelow) {
+        window.scrollBy({
+          top: rect.bottom - (window.innerHeight || document.documentElement.clientHeight) + 10,
+          behavior: 'smooth',
+        });
+      }
+
+      if (isLeft) {
+        window.scrollBy({ left: rect.left - 10, behavior: 'smooth' });
+      } else if (isRight) {
+        window.scrollBy({
+          left: rect.right - (window.innerWidth || document.documentElement.clientWidth) + 10,
+          behavior: 'smooth',
+        });
+      }
+    };
     // scroll when not in view
-    listContainer.querySelector(`.${classNames.selected}`)?.scrollIntoView({ block: 'center' });
+    scrollIntoViewIfNeeded(listContainer.querySelector(`.${classNames.selected}`) as HTMLDivElement);
 
     show();
   };
@@ -609,9 +636,7 @@ const typeahead = <T extends Dictionary>(config: typeaheadConfig<T>): typeaheadR
 
     fetchWrapper
       .get(
-        typeof remote.url === 'function'
-          ? remote.url(frozenInput)
-          : remote.url.replace(remote.wildcard!, frozenInput),
+        typeof remote.url === 'function' ? remote.url(frozenInput) : remote.url.replace(remote.wildcard!, frozenInput),
         remote.requestOptions
       )
       .then(

--- a/src/typeahead-standalone.ts
+++ b/src/typeahead-standalone.ts
@@ -374,8 +374,11 @@ const typeahead = <T extends Dictionary>(config: typeaheadConfig<T>): typeaheadR
 
     listContainer.appendChild(fragment);
 
+    // update hint if its enabled
+    hint && updateHint(selected || resultSet.hits[0]);
+
     // scroll when not in view
-    listContainer.querySelector(`.${classNames.selected}`)?.scrollIntoView({ block: 'nearest', behavior: 'smooth'});
+    listContainer.querySelector(`.${classNames.selected}`)?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
     show();
   };
 

--- a/src/typeahead-standalone.ts
+++ b/src/typeahead-standalone.ts
@@ -377,31 +377,8 @@ const typeahead = <T extends Dictionary>(config: typeaheadConfig<T>): typeaheadR
     // update hint if its enabled
     hint && updateHint(selected || resultSet.hits[0]);
 
-    const scrollIntoViewIfNeeded = (container: HTMLDivElement, element: HTMLDivElement) => {
-      if (container === null || element === null) return;
-
-      const containerRect = container.getBoundingClientRect();
-      const elementRect = element.getBoundingClientRect();
-
-      const isAbove = elementRect.top < containerRect.top;
-      const isBelow = elementRect.bottom > containerRect.bottom;
-      const isLeft = elementRect.left < containerRect.left;
-      const isRight = elementRect.right > containerRect.right;
-
-      if (isAbove) {
-        container.scrollBy({ top: elementRect.top - containerRect.top - 10, behavior: 'smooth' });
-      } else if (isBelow) {
-        container.scrollBy({ top: elementRect.bottom - containerRect.bottom + 10, behavior: 'smooth' });
-      }
-
-      if (isLeft) {
-        container.scrollBy({ left: elementRect.left - containerRect.left - 10, behavior: 'smooth' });
-      } else if (isRight) {
-        container.scrollBy({ left: elementRect.right - containerRect.right + 10, behavior: 'smooth' });
-      }
-    };
     // scroll when not in view
-    scrollIntoViewIfNeeded(listContainer, listContainer.querySelector(`.${classNames.selected}`) as HTMLDivElement);
+    listContainer.querySelector(`.${classNames.selected}`)?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
 
     show();
   };
@@ -632,9 +609,7 @@ const typeahead = <T extends Dictionary>(config: typeaheadConfig<T>): typeaheadR
 
     fetchWrapper
       .get(
-        typeof remote.url === 'function'
-          ? remote.url(frozenInput)
-          : remote.url.replace(remote.wildcard!, frozenInput),
+        typeof remote.url === 'function' ? remote.url(frozenInput) : remote.url.replace(remote.wildcard!, frozenInput),
         remote.requestOptions
       )
       .then(

--- a/src/typeahead-standalone.ts
+++ b/src/typeahead-standalone.ts
@@ -374,11 +374,10 @@ const typeahead = <T extends Dictionary>(config: typeaheadConfig<T>): typeaheadR
 
     listContainer.appendChild(fragment);
 
-    // update hint if its enabled
     hint && updateHint(selected || resultSet.hits[0]);
 
     // scroll when not in view
-    listContainer.querySelector(`.${classNames.selected}`)?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    listContainer.querySelector(`.${classNames.selected}`)?.scrollIntoView({ block: 'nearest', behavior: 'smooth'});
     show();
   };
 
@@ -608,7 +607,9 @@ const typeahead = <T extends Dictionary>(config: typeaheadConfig<T>): typeaheadR
 
     fetchWrapper
       .get(
-        typeof remote.url === 'function' ? remote.url(frozenInput) : remote.url.replace(remote.wildcard!, frozenInput),
+        typeof remote.url === 'function'
+          ? remote.url(frozenInput)
+          : remote.url.replace(remote.wildcard!, frozenInput),
         remote.requestOptions
       )
       .then(

--- a/src/typeahead-standalone.ts
+++ b/src/typeahead-standalone.ts
@@ -377,8 +377,31 @@ const typeahead = <T extends Dictionary>(config: typeaheadConfig<T>): typeaheadR
     // update hint if its enabled
     hint && updateHint(selected || resultSet.hits[0]);
 
+    const scrollIntoViewIfNeeded = (container: HTMLDivElement, element: HTMLDivElement) => {
+      if (container === null || element === null) return;
+
+      const containerRect = container.getBoundingClientRect();
+      const elementRect = element.getBoundingClientRect();
+
+      const isAbove = elementRect.top < containerRect.top;
+      const isBelow = elementRect.bottom > containerRect.bottom;
+      const isLeft = elementRect.left < containerRect.left;
+      const isRight = elementRect.right > containerRect.right;
+
+      if (isAbove) {
+        container.scrollBy({ top: elementRect.top - containerRect.top - 10, behavior: 'smooth' });
+      } else if (isBelow) {
+        container.scrollBy({ top: elementRect.bottom - containerRect.bottom + 10, behavior: 'smooth' });
+      }
+
+      if (isLeft) {
+        container.scrollBy({ left: elementRect.left - containerRect.left - 10, behavior: 'smooth' });
+      } else if (isRight) {
+        container.scrollBy({ left: elementRect.right - containerRect.right + 10, behavior: 'smooth' });
+      }
+    };
     // scroll when not in view
-    listContainer.querySelector(`.${classNames.selected}`)?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    scrollIntoViewIfNeeded(listContainer, listContainer.querySelector(`.${classNames.selected}`) as HTMLDivElement);
 
     show();
   };

--- a/src/typeahead-standalone.ts
+++ b/src/typeahead-standalone.ts
@@ -377,35 +377,31 @@ const typeahead = <T extends Dictionary>(config: typeaheadConfig<T>): typeaheadR
     // update hint if its enabled
     hint && updateHint(selected || resultSet.hits[0]);
 
-    const scrollIntoViewIfNeeded = (element: HTMLDivElement) => {
-      if (element === null) return;
-      const rect = element.getBoundingClientRect();
+    const scrollIntoViewIfNeeded = (container: HTMLDivElement, element: HTMLDivElement) => {
+      if (container === null || element === null) return;
 
-      const isAbove = rect.top < 0;
-      const isBelow = rect.bottom > (window.innerHeight || document.documentElement.clientHeight);
-      const isLeft = rect.left < 0;
-      const isRight = rect.right > (window.innerWidth || document.documentElement.clientWidth);
+      const containerRect = container.getBoundingClientRect();
+      const elementRect = element.getBoundingClientRect();
+
+      const isAbove = elementRect.top < containerRect.top;
+      const isBelow = elementRect.bottom > containerRect.bottom;
+      const isLeft = elementRect.left < containerRect.left;
+      const isRight = elementRect.right > containerRect.right;
 
       if (isAbove) {
-        window.scrollBy({ top: rect.top - 10, behavior: 'smooth' });
+        container.scrollBy({ top: elementRect.top - containerRect.top - 10, behavior: 'smooth' });
       } else if (isBelow) {
-        window.scrollBy({
-          top: rect.bottom - (window.innerHeight || document.documentElement.clientHeight) + 10,
-          behavior: 'smooth',
-        });
+        container.scrollBy({ top: elementRect.bottom - containerRect.bottom + 10, behavior: 'smooth' });
       }
 
       if (isLeft) {
-        window.scrollBy({ left: rect.left - 10, behavior: 'smooth' });
+        container.scrollBy({ left: elementRect.left - containerRect.left - 10, behavior: 'smooth' });
       } else if (isRight) {
-        window.scrollBy({
-          left: rect.right - (window.innerWidth || document.documentElement.clientWidth) + 10,
-          behavior: 'smooth',
-        });
+        container.scrollBy({ left: elementRect.right - containerRect.right + 10, behavior: 'smooth' });
       }
     };
     // scroll when not in view
-    scrollIntoViewIfNeeded(listContainer.querySelector(`.${classNames.selected}`) as HTMLDivElement);
+    scrollIntoViewIfNeeded(listContainer, listContainer.querySelector(`.${classNames.selected}`) as HTMLDivElement);
 
     show();
   };


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [X] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `develop` branch (or `v[X]` branch)
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: [#xxx]`, where "xxx" is the issue number)
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/digitalfortress-tech/localstorage-slim#readme) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.


**Other information:**
Previously, when navigating through a list of suggestions using the arrow keys, the window would scroll to center the selected item every time, even if it was already in view. This update modifies that behavior: the window will now only scroll when necessary to keep the selected item visible. This change enhances the overall usability of the package by providing a smoother and more intuitive browsing experience.